### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.26](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.1.25...pie-boot-loader-aarch64-v0.1.26) - 2025-07-22
+
+### Other
+
+- V03 ([#29](https://github.com/rcore-os/somehal/pull/29))
+
 ## [0.1.25](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.24...pie-boot-loader-aarch64-v0.1.25) - 2025-07-08
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.25"
+version = "0.1.26"
 
 [features]
 console = ["dep:any-uart"]

--- a/somehal/CHANGELOG.md
+++ b/somehal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/rcore-os/somehal/compare/somehal-v0.3.0...somehal-v0.3.1) - 2025-07-22
+
+### Other
+
+- 更新测试配置，移除构建步骤并修正文档中的项目名称
+
 ## [0.2.20](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.19...pie-boot-v0.2.20) - 2025-07-08
 
 ### Other

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.3.0"
+version = "0.3.1"
 
 [features]
 hv = ["pie-boot-loader-aarch64/el2", "kdef-pgtable/space-low"]
@@ -28,7 +28,7 @@ log = "0.4"
 aarch64-cpu = "10.0"
 aarch64-cpu-ext = "0.1"
 kasm-aarch64 = {workspace = true}
-pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.25" }
+pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.26" }
 smccc = "0.2"
 
 [build-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-loader-aarch64`: 0.1.25 -> 0.1.26 (✓ API compatible changes)
* `somehal`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.26](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.1.25...pie-boot-loader-aarch64-v0.1.26) - 2025-07-22

### Other

- V03 ([#29](https://github.com/rcore-os/somehal/pull/29))
</blockquote>

## `somehal`

<blockquote>

## [0.3.1](https://github.com/rcore-os/somehal/compare/somehal-v0.3.0...somehal-v0.3.1) - 2025-07-22

### Other

- 更新测试配置，移除构建步骤并修正文档中的项目名称
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).