### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "kasm-aarch64"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-macros"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.27](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.1.26...pie-boot-loader-aarch64-v0.1.27) - 2025-07-24
+
+### Other
+
+- 简化trap
+- add irq handler
+
 ## [0.1.26](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.1.25...pie-boot-loader-aarch64-v0.1.26) - 2025-07-22
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.26"
+version = "0.1.27"
 
 [features]
 console = ["dep:any-uart"]

--- a/macros/kasm-aarch64/CHANGELOG.md
+++ b/macros/kasm-aarch64/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/rcore-os/somehal/compare/kasm-aarch64-v0.1.2...kasm-aarch64-v0.1.3) - 2025-07-24
+
+### Other
+
+- 简化trap
+- fmt
+- add irq handler
+
 ## [0.1.2](https://github.com/rcore-os/pie-boot/compare/kasm-aarch64-v0.1.1...kasm-aarch64-v0.1.2) - 2025-06-17
 
 ### Fixed

--- a/macros/kasm-aarch64/Cargo.toml
+++ b/macros/kasm-aarch64/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.2"
+version = "0.1.3"
 
 [lib]
 proc-macro = true

--- a/macros/pie-boot-macros/CHANGELOG.md
+++ b/macros/pie-boot-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/rcore-os/somehal/compare/pie-boot-macros-v0.1.2...pie-boot-macros-v0.1.3) - 2025-07-24
+
+### Other
+
+- add irq handler
+
 ## [0.1.2](https://github.com/rcore-os/pie-boot/compare/pie-boot-macros-v0.1.1...pie-boot-macros-v0.1.2) - 2025-07-08
 
 ### Added

--- a/macros/pie-boot-macros/Cargo.toml
+++ b/macros/pie-boot-macros/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.2"
+version = "0.1.3"
 
 [lib]
 proc-macro = true

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4"
 aarch64-cpu = "10.0"
 aarch64-cpu-ext = "0.1"
 kasm-aarch64 = {workspace = true}
-pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.26" }
+pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.27" }
 smccc = "0.2"
 
 [build-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-macros`: 0.1.2 -> 0.1.3
* `kasm-aarch64`: 0.1.2 -> 0.1.3
* `pie-boot-loader-aarch64`: 0.1.26 -> 0.1.27 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-macros`

<blockquote>

## [0.1.3](https://github.com/rcore-os/somehal/compare/pie-boot-macros-v0.1.2...pie-boot-macros-v0.1.3) - 2025-07-24

### Other

- add irq handler
</blockquote>

## `kasm-aarch64`

<blockquote>

## [0.1.3](https://github.com/rcore-os/somehal/compare/kasm-aarch64-v0.1.2...kasm-aarch64-v0.1.3) - 2025-07-24

### Other

- 简化trap
- fmt
- add irq handler
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.27](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.1.26...pie-boot-loader-aarch64-v0.1.27) - 2025-07-24

### Other

- 简化trap
- add irq handler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).