### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.0...pie-boot-loader-aarch64-v0.2.1) - 2025-08-18
+
+### Other
+
+- 移除对EL配置的条件编译，改为运行时检查当前EL级别
+
 ## [0.2.0](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.1.26...pie-boot-loader-aarch64-v0.2.0) - 2025-07-24
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 aarch64-cpu = "10.0"

--- a/somehal/CHANGELOG.md
+++ b/somehal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/rcore-os/somehal/compare/somehal-v0.3.3...somehal-v0.3.4) - 2025-08-18
+
+### Other
+
+- Loader 改为动态参数 ([#35](https://github.com/rcore-os/somehal/pull/35))
+
 ## [0.3.3](https://github.com/rcore-os/somehal/compare/somehal-v0.3.2...somehal-v0.3.3) - 2025-07-24
 
 ### Other

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.3.3"
+version = "0.3.4"
 
 [features]
 hv = ["kdef-pgtable/space-low"]


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-loader-aarch64`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `somehal`: 0.3.3 -> 0.3.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.2.1](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.0...pie-boot-loader-aarch64-v0.2.1) - 2025-08-18

### Other

- 移除对EL配置的条件编译，改为运行时检查当前EL级别
</blockquote>

## `somehal`

<blockquote>

## [0.3.4](https://github.com/rcore-os/somehal/compare/somehal-v0.3.3...somehal-v0.3.4) - 2025-08-18

### Other

- Loader 改为动态参数 ([#35](https://github.com/rcore-os/somehal/pull/35))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).