### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.1...pie-boot-loader-aarch64-v0.2.2) - 2025-08-19
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.2.1](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.0...pie-boot-loader-aarch64-v0.2.1) - 2025-08-18
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 aarch64-cpu = "10.0"

--- a/somehal/CHANGELOG.md
+++ b/somehal/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/rcore-os/somehal/compare/somehal-v0.3.4...somehal-v0.3.5) - 2025-08-19
+
+### Other
+
+- 添加对 pie-boot-loader-aarch64 的支持，更新依赖项，新增 Gitee 和 GitHub 的发布获取功能
+- Use prebuild loader
+
 ## [0.3.4](https://github.com/rcore-os/somehal/compare/somehal-v0.3.3...somehal-v0.3.4) - 2025-08-18
 
 ### Other

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.3.4"
+version = "0.3.5"
 
 [features]
 hv = ["kdef-pgtable/space-low"]


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-loader-aarch64`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `somehal`: 0.3.4 -> 0.3.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.2.2](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.1...pie-boot-loader-aarch64-v0.2.2) - 2025-08-19

### Other

- update Cargo.lock dependencies
</blockquote>

## `somehal`

<blockquote>

## [0.3.5](https://github.com/rcore-os/somehal/compare/somehal-v0.3.4...somehal-v0.3.5) - 2025-08-19

### Other

- 添加对 pie-boot-loader-aarch64 的支持，更新依赖项，新增 Gitee 和 GitHub 的发布获取功能
- Use prebuild loader
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).