### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "kasm-aarch64"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/macros/kasm-aarch64/CHANGELOG.md
+++ b/macros/kasm-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/rcore-os/somehal/compare/kasm-aarch64-v0.1.3...kasm-aarch64-v0.1.4) - 2025-08-19
+
+### Fixed
+
+- use macros adr_l instead of asm macro
+
 ## [0.1.3](https://github.com/rcore-os/somehal/compare/kasm-aarch64-v0.1.2...kasm-aarch64-v0.1.3) - 2025-07-24
 
 ### Other

--- a/macros/kasm-aarch64/Cargo.toml
+++ b/macros/kasm-aarch64/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.3"
+version = "0.1.4"
 
 [lib]
 proc-macro = true

--- a/somehal/CHANGELOG.md
+++ b/somehal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/rcore-os/somehal/compare/somehal-v0.3.5...somehal-v0.3.6) - 2025-08-19
+
+### Fixed
+
+- use macros adr_l instead of asm macro
+
 ## [0.3.5](https://github.com/rcore-os/somehal/compare/somehal-v0.3.4...somehal-v0.3.5) - 2025-08-18
 
 ### Other

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.3.5"
+version = "0.3.6"
 
 [features]
 hv = ["kdef-pgtable/space-low"]


### PR DESCRIPTION



## 🤖 New release

* `kasm-aarch64`: 0.1.3 -> 0.1.4
* `somehal`: 0.3.5 -> 0.3.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `kasm-aarch64`

<blockquote>

## [0.1.4](https://github.com/rcore-os/somehal/compare/kasm-aarch64-v0.1.3...kasm-aarch64-v0.1.4) - 2025-08-19

### Fixed

- use macros adr_l instead of asm macro
</blockquote>

## `somehal`

<blockquote>

## [0.3.6](https://github.com/rcore-os/somehal/compare/somehal-v0.3.5...somehal-v0.3.6) - 2025-08-19

### Fixed

- use macros adr_l instead of asm macro
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).