### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.2...pie-boot-loader-aarch64-v0.2.3) - 2025-08-19
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.2.2](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.1...pie-boot-loader-aarch64-v0.2.2) - 2025-08-18
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies]
 aarch64-cpu = "10.0"

--- a/somehal/CHANGELOG.md
+++ b/somehal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/rcore-os/somehal/compare/somehal-v0.3.6...somehal-v0.3.7) - 2025-08-19
+
+### Added
+
+- 添加 LazyStatic 的 clean 方法并在 virt_entry 中调用
+
 ## [0.3.6](https://github.com/rcore-os/somehal/compare/somehal-v0.3.5...somehal-v0.3.6) - 2025-08-19
 
 ### Fixed

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.3.6"
+version = "0.3.7"
 
 [features]
 hv = ["kdef-pgtable/space-low"]


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-loader-aarch64`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `somehal`: 0.3.6 -> 0.3.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.2.3](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.2...pie-boot-loader-aarch64-v0.2.3) - 2025-08-19

### Other

- update Cargo.lock dependencies
</blockquote>

## `somehal`

<blockquote>

## [0.3.7](https://github.com/rcore-os/somehal/compare/somehal-v0.3.6...somehal-v0.3.7) - 2025-08-19

### Added

- 添加 LazyStatic 的 clean 方法并在 virt_entry 中调用
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).