### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,18 +1276,6 @@ dependencies = [
 [[package]]
 name = "page-table-generic"
 version = "0.6.0"
-dependencies = [
- "bitflags 2.9.2",
- "env_logger",
- "log",
- "num-align",
- "thiserror 2.0.15",
- "tock-registers 0.9.0",
-]
-
-[[package]]
-name = "page-table-generic"
-version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79217ff706e8dd356df4b6d624bae950ae5c39a17c6959b81d73dedfc9653316"
 dependencies = [
@@ -1295,6 +1283,18 @@ dependencies = [
  "log",
  "num-align",
  "thiserror 2.0.15",
+]
+
+[[package]]
+name = "page-table-generic"
+version = "0.6.1"
+dependencies = [
+ "bitflags 2.9.2",
+ "env_logger",
+ "log",
+ "num-align",
+ "thiserror 2.0.15",
+ "tock-registers 0.9.0",
 ]
 
 [[package]]
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1346,7 +1346,7 @@ dependencies = [
  "kdef-pgtable",
  "log",
  "num-align",
- "page-table-generic 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "page-table-generic 0.6.0",
  "pie-boot-if",
  "prettyplease",
  "quote",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1914,7 +1914,7 @@ dependencies = [
  "kdef-pgtable",
  "log",
  "num-align",
- "page-table-generic 0.6.0",
+ "page-table-generic 0.6.1",
  "pie-boot-if",
  "pie-boot-loader-aarch64",
  "pie-boot-macros",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.4...pie-boot-loader-aarch64-v0.2.5) - 2025-09-11
+
+### Fixed
+
+- cpu on cache
+
 ## [0.2.4](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.3...pie-boot-loader-aarch64-v0.2.4) - 2025-08-22
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.2.4"
+version = "0.2.5"
 
 [dependencies]
 aarch64-cpu = "10.0"

--- a/page-table-generic/CHANGELOG.md
+++ b/page-table-generic/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.1](https://github.com/rcore-os/somehal/compare/page-table-generic-v0.6.0...page-table-generic-v0.6.1) - 2025-09-11
+
+### Fixed
+
+- cpu_on

--- a/page-table-generic/Cargo.toml
+++ b/page-table-generic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "page-table-generic"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["周睿 <zrufo747@outlook.com>"]
 repository = "https://github.com/rcore-os/somehal/page-table-generic"
 documentation = "https://docs.rs/page-table-generic"

--- a/somehal/CHANGELOG.md
+++ b/somehal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.13](https://github.com/rcore-os/somehal/compare/somehal-v0.3.12...somehal-v0.3.13) - 2025-09-11
+
+### Fixed
+
+- cpu on cache
+
 ## [0.3.9](https://github.com/rcore-os/somehal/compare/somehal-v0.3.7...somehal-v0.3.9) - 2025-08-19
 
 ### Added

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.3.12"
+version = "0.3.13"
 
 [features]
 hv = ["kdef-pgtable/space-low"]


### PR DESCRIPTION



## 🤖 New release

* `page-table-generic`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `pie-boot-loader-aarch64`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `somehal`: 0.3.12 -> 0.3.13 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `page-table-generic`

<blockquote>

## [0.6.1](https://github.com/rcore-os/somehal/compare/page-table-generic-v0.6.0...page-table-generic-v0.6.1) - 2025-09-11

### Fixed

- cpu_on
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.2.5](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.2.4...pie-boot-loader-aarch64-v0.2.5) - 2025-09-11

### Fixed

- cpu on cache
</blockquote>

## `somehal`

<blockquote>

## [0.3.13](https://github.com/rcore-os/somehal/compare/somehal-v0.3.12...somehal-v0.3.13) - 2025-09-11

### Fixed

- cpu on cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).