### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.3.1...pie-boot-loader-aarch64-v0.3.2) - 2025-09-22
+
+### Added
+
+- 添加 spin 依赖并实现共享数据的互斥锁管理 ([#50](https://github.com/rcore-os/somehal/pull/50))
+
 ## [0.3.1](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.3.0...pie-boot-loader-aarch64-v0.3.1) - 2025-09-19
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
 aarch64-cpu = "10.0"

--- a/somehal/CHANGELOG.md
+++ b/somehal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/rcore-os/somehal/compare/somehal-v0.4.1...somehal-v0.4.2) - 2025-09-22
+
+### Added
+
+- 添加 spin 依赖并实现共享数据的互斥锁管理 ([#50](https://github.com/rcore-os/somehal/pull/50))
+
 ## [0.4.1](https://github.com/rcore-os/somehal/compare/somehal-v0.3.12...somehal-v0.4.1) - 2025-09-11
 
 ### Fixed

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.4.1"
+version = "0.4.2"
 
 [features]
 hv = ["kdef-pgtable/space-low"]


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-loader-aarch64`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `somehal`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.3.2](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.3.1...pie-boot-loader-aarch64-v0.3.2) - 2025-09-22

### Added

- 添加 spin 依赖并实现共享数据的互斥锁管理 ([#50](https://github.com/rcore-os/somehal/pull/50))
</blockquote>

## `somehal`

<blockquote>

## [0.4.2](https://github.com/rcore-os/somehal/compare/somehal-v0.4.1...somehal-v0.4.2) - 2025-09-22

### Added

- 添加 spin 依赖并实现共享数据的互斥锁管理 ([#50](https://github.com/rcore-os/somehal/pull/50))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).