### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "page-table-generic"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "bitflags 2.9.4",
  "env_logger",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/page-table-generic/CHANGELOG.md
+++ b/page-table-generic/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.7](https://github.com/rcore-os/somehal/compare/page-table-generic-v0.6.6...page-table-generic-v0.6.7) - 2026-04-01
+
+### Fixed
+
+- cpu_on
+- fix pg blk ([#2](https://github.com/rcore-os/somehal/pull/2))
+
+### Other
+
+- release ([#66](https://github.com/rcore-os/somehal/pull/66))
+- release ([#63](https://github.com/rcore-os/somehal/pull/63))
+- release ([#60](https://github.com/rcore-os/somehal/pull/60))
+- release ([#59](https://github.com/rcore-os/somehal/pull/59))
+- release ([#58](https://github.com/rcore-os/somehal/pull/58))
+- release ([#46](https://github.com/rcore-os/somehal/pull/46))
+- Implement a generic page table structure and associated traits
+- V03 ([#29](https://github.com/rcore-os/somehal/pull/29))
+- add rdrive
+- 11 项目结构优化 ([#12](https://github.com/rcore-os/somehal/pull/12))
+- 增加主存保留信息分配器及优化代码 ([#10](https://github.com/rcore-os/somehal/pull/10))
+- Move mmu relocate to pie-boot ([#8](https://github.com/rcore-os/somehal/pull/8))
+- fmt
+- 增加Riscv支持 ([#3](https://github.com/rcore-os/somehal/pull/3))
+- update
+- update
+- add riscv
+- update
+- update
+- fmt
+- update
+- update
+- page table
+- page table ok
+- update
+- update
+- update
+
 ## [0.6.6](https://github.com/rcore-os/somehal/compare/page-table-generic-v0.6.5...page-table-generic-v0.6.6) - 2026-04-01
 
 ### Other

--- a/page-table-generic/Cargo.toml
+++ b/page-table-generic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "page-table-generic"
-version = "0.6.6"
+version = "0.6.7"
 authors = ["周睿 <zrufo747@outlook.com>"]
 repository = "https://github.com/rcore-os/somehal/page-table-generic"
 documentation = "https://docs.rs/page-table-generic"

--- a/somehal/CHANGELOG.md
+++ b/somehal/CHANGELOG.md
@@ -7,6 +7,226 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.12](https://github.com/rcore-os/somehal/compare/somehal-v0.4.11...somehal-v0.4.12) - 2026-04-01
+
+### Added
+
+- Remove merge/split memory functionality, change to merge same-type regions only ([#62](https://github.com/rcore-os/somehal/pull/62))
+- merge overlaps region and delete reserved/bootloader from ram region ([#56](https://github.com/rcore-os/somehal/pull/56))
+- implement UART RX handling and add read functions, simplify RAM finding logic ([#53](https://github.com/rcore-os/somehal/pull/53))
+- 添加 write_bytes 函数以支持批量写入字节
+- add debug
+- 添加 spin 依赖并实现共享数据的互斥锁管理 ([#50](https://github.com/rcore-os/somehal/pull/50))
+- add cpu_on
+- 添加 LazyStatic 的 clean 方法并在 virt_entry 中调用
+
+### Fixed
+
+- *(aarch64)* 修正异常寄存器读取与内核映射偏移 ([#65](https://github.com/rcore-os/somehal/pull/65))
+- support hypervisor mode EL2 boot and refactor CI ([#55](https://github.com/rcore-os/somehal/pull/55))
+- static section
+- 更新版本号至 0.3.15
+- rsv aligin
+- cpu_on
+- cpu on cache
+- cpu_on
+- 修复内核表地址设置逻辑并更新版本号至 0.3.11
+- update cpu_on return type to use PsciError for consistency
+- use macros adr_l instead of asm macro
+- fix
+- fix log
+- percpu data
+- find memory
+- fix aarch64 cpu on cache
+- fix link before mmu
+- fix riscv cpuid
+- fix pg blk ([#2](https://github.com/rcore-os/somehal/pull/2))
+- fix section
+
+### Other
+
+- release ([#66](https://github.com/rcore-os/somehal/pull/66))
+- release ([#63](https://github.com/rcore-os/somehal/pull/63))
+- release ([#60](https://github.com/rcore-os/somehal/pull/60))
+- release ([#59](https://github.com/rcore-os/somehal/pull/59))
+- release ([#58](https://github.com/rcore-os/somehal/pull/58))
+- *(somehal)* release v0.4.6 ([#57](https://github.com/rcore-os/somehal/pull/57))
+- *(somehal)* release v0.4.5 ([#54](https://github.com/rcore-os/somehal/pull/54))
+- release ([#51](https://github.com/rcore-os/somehal/pull/51))
+- aarch64 bootloader stack use kernel stack
+- release ([#46](https://github.com/rcore-os/somehal/pull/46))
+- Implement a generic page table structure and associated traits
+- 更新版本号至 0.3.9
+- *(somehal)* release v0.3.8 ([#42](https://github.com/rcore-os/somehal/pull/42))
+- static link to .data to avoid bss clean by others
+- release ([#41](https://github.com/rcore-os/somehal/pull/41))
+- release ([#39](https://github.com/rcore-os/somehal/pull/39))
+- release ([#37](https://github.com/rcore-os/somehal/pull/37))
+- 添加对 pie-boot-loader-aarch64 的支持，更新依赖项，新增 Gitee 和 GitHub 的发布获取功能
+- Use prebuild loader
+- *(somehal)* release v0.3.4 ([#36](https://github.com/rcore-os/somehal/pull/36))
+- Loader 改为动态参数 ([#35](https://github.com/rcore-os/somehal/pull/35))
+- *(somehal)* release v0.3.3 ([#33](https://github.com/rcore-os/somehal/pull/33))
+- 在README中添加测试状态徽章
+- *(somehal)* release v0.3.2 ([#32](https://github.com/rcore-os/somehal/pull/32))
+- release ([#31](https://github.com/rcore-os/somehal/pull/31))
+- 简化trap
+- add irq handler
+- release ([#30](https://github.com/rcore-os/somehal/pull/30))
+- 更新测试配置，移除构建步骤并修正文档中的项目名称
+- V03 ([#29](https://github.com/rcore-os/somehal/pull/29))
+- Make fdt_ptr() function public ([#28](https://github.com/rcore-os/somehal/pull/28))
+- 更新 Rust 分析器配置，启用 "vm" 特性；优化 EL2 切换函数，改用写入方式修改 HCR_EL2；在页表配置中添加共享标志并处理缓存配置。
+- log
+- update
+- update rdrive
+- use new rdrive if
+- update rdrive
+- new rdrive macros
+- add rx
+- update rdrive
+- update
+- update
+- 优化串口输出
+- update
+- add el2 clk
+- update rdrive
+- update rdrive
+- update
+- 移除percpu依赖 ([#27](https://github.com/rcore-os/somehal/pull/27))
+- 优化串口输出
+- update
+- update
+- console out add \r
+- adapt percpu feature
+- adapt percpu
+- adapt percpu
+- 25 el2 support ([#26](https://github.com/rcore-os/somehal/pull/26))
+- riscv boot
+- update
+- update
+- update
+- update
+- percpu smp ([#24](https://github.com/rcore-os/somehal/pull/24))
+- 2 cpu on  ([#23](https://github.com/rcore-os/somehal/pull/23))
+- update
+- update
+- update ([#22](https://github.com/rcore-os/somehal/pull/22))
+- update
+- fmt
+- update
+- update
+- update
+- update
+- update
+- update
+- update
+- 调整 rdrive 链接位置
+- update
+- update
+- update
+- update
+- update
+- update
+- update
+- update
+- power
+- update
+- update
+- add rdrive
+- 优化ld
+- Merge branch 'main' into 20-引入动态驱动框架实现中断控制器和定时器枚举
+- [fix] 树莓派
+- update
+- fmt
+- x86 use any uart
+- 18 优化链接脚本便于引入 ([#19](https://github.com/rcore-os/somehal/pull/19))
+- 添加x86-64支持 ([#17](https://github.com/rcore-os/somehal/pull/17))
+- update
+- [fix]add clean bss
+- cpu and memory found
+- update
+- update
+- update
+- update
+- main memory
+- rsv
+- update
+- x86 cpu list
+- 11 项目结构优化 ([#12](https://github.com/rcore-os/somehal/pull/12))
+- 增加主存保留信息分配器及优化代码 ([#10](https://github.com/rcore-os/somehal/pull/10))
+- [fix] starfive2 support ([#9](https://github.com/rcore-os/somehal/pull/9))
+- update
+- sv39 support
+- Move mmu relocate to pie-boot ([#8](https://github.com/rcore-os/somehal/pull/8))
+- add dcache flush
+- update
+- fmt
+- update
+- fmt
+- percpu data ok
+- update
+- entry
+- 增加Riscv支持 ([#3](https://github.com/rcore-os/somehal/pull/3))
+- update
+- fmt
+- fmt
+- update
+- add riscv
+- update
+- update
+- update
+- update
+- update
+- update
+- update
+- update
+- fmt code
+- update
+- update
+- mmu ok
+- init
+- update
+- fmt
+- fmt
+- update
+- fmt code
+- updte
+- update
+- qemu debug
+- update
+- print
+- update
+- pte
+- debug
+- uboot debug ok
+- update
+- update
+- update
+- update
+- u
+- update
+- update
+- update
+- 内存区域划分
+- update
+- update
+- page table
+- update
+- update
+- update
+- update
+- link to boot
+- update
+- update
+- update
+- debug ok
+- debug ok
+- update
+- update
+- update
+- init
+
 ## [0.4.11](https://github.com/rcore-os/somehal/compare/somehal-v0.4.10...somehal-v0.4.11) - 2026-04-01
 
 ### Fixed

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.4.11"
+version = "0.4.12"
 
 [features]
 hv = ["kdef-pgtable/space-low"]


### PR DESCRIPTION



## 🤖 New release

* `page-table-generic`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `pie-boot-loader-aarch64`: 0.3.5 -> 0.3.6
* `somehal`: 0.4.11 -> 0.4.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `page-table-generic`

<blockquote>

## [0.6.7](https://github.com/rcore-os/somehal/compare/page-table-generic-v0.6.6...page-table-generic-v0.6.7) - 2026-04-01

### Fixed

- cpu_on
- fix pg blk ([#2](https://github.com/rcore-os/somehal/pull/2))

### Other

- release ([#66](https://github.com/rcore-os/somehal/pull/66))
- release ([#63](https://github.com/rcore-os/somehal/pull/63))
- release ([#60](https://github.com/rcore-os/somehal/pull/60))
- release ([#59](https://github.com/rcore-os/somehal/pull/59))
- release ([#58](https://github.com/rcore-os/somehal/pull/58))
- release ([#46](https://github.com/rcore-os/somehal/pull/46))
- Implement a generic page table structure and associated traits
- V03 ([#29](https://github.com/rcore-os/somehal/pull/29))
- add rdrive
- 11 项目结构优化 ([#12](https://github.com/rcore-os/somehal/pull/12))
- 增加主存保留信息分配器及优化代码 ([#10](https://github.com/rcore-os/somehal/pull/10))
- Move mmu relocate to pie-boot ([#8](https://github.com/rcore-os/somehal/pull/8))
- fmt
- 增加Riscv支持 ([#3](https://github.com/rcore-os/somehal/pull/3))
- update
- update
- add riscv
- update
- update
- fmt
- update
- update
- page table
- page table ok
- update
- update
- update
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.3.6](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.3.5...pie-boot-loader-aarch64-v0.3.6) - 2026-04-01

### Fixed

- *(aarch64)* 修正异常寄存器读取与内核映射偏移 ([#65](https://github.com/rcore-os/somehal/pull/65))
</blockquote>

## `somehal`

<blockquote>

## [0.4.12](https://github.com/rcore-os/somehal/compare/somehal-v0.4.11...somehal-v0.4.12) - 2026-04-01

### Added

- Remove merge/split memory functionality, change to merge same-type regions only ([#62](https://github.com/rcore-os/somehal/pull/62))
- merge overlaps region and delete reserved/bootloader from ram region ([#56](https://github.com/rcore-os/somehal/pull/56))
- implement UART RX handling and add read functions, simplify RAM finding logic ([#53](https://github.com/rcore-os/somehal/pull/53))
- 添加 write_bytes 函数以支持批量写入字节
- add debug
- 添加 spin 依赖并实现共享数据的互斥锁管理 ([#50](https://github.com/rcore-os/somehal/pull/50))
- add cpu_on
- 添加 LazyStatic 的 clean 方法并在 virt_entry 中调用

### Fixed

- *(aarch64)* 修正异常寄存器读取与内核映射偏移 ([#65](https://github.com/rcore-os/somehal/pull/65))
- support hypervisor mode EL2 boot and refactor CI ([#55](https://github.com/rcore-os/somehal/pull/55))
- static section
- 更新版本号至 0.3.15
- rsv aligin
- cpu_on
- cpu on cache
- cpu_on
- 修复内核表地址设置逻辑并更新版本号至 0.3.11
- update cpu_on return type to use PsciError for consistency
- use macros adr_l instead of asm macro
- fix
- fix log
- percpu data
- find memory
- fix aarch64 cpu on cache
- fix link before mmu
- fix riscv cpuid
- fix pg blk ([#2](https://github.com/rcore-os/somehal/pull/2))
- fix section

### Other

- release ([#66](https://github.com/rcore-os/somehal/pull/66))
- release ([#63](https://github.com/rcore-os/somehal/pull/63))
- release ([#60](https://github.com/rcore-os/somehal/pull/60))
- release ([#59](https://github.com/rcore-os/somehal/pull/59))
- release ([#58](https://github.com/rcore-os/somehal/pull/58))
- *(somehal)* release v0.4.6 ([#57](https://github.com/rcore-os/somehal/pull/57))
- *(somehal)* release v0.4.5 ([#54](https://github.com/rcore-os/somehal/pull/54))
- release ([#51](https://github.com/rcore-os/somehal/pull/51))
- aarch64 bootloader stack use kernel stack
- release ([#46](https://github.com/rcore-os/somehal/pull/46))
- Implement a generic page table structure and associated traits
- 更新版本号至 0.3.9
- *(somehal)* release v0.3.8 ([#42](https://github.com/rcore-os/somehal/pull/42))
- static link to .data to avoid bss clean by others
- release ([#41](https://github.com/rcore-os/somehal/pull/41))
- release ([#39](https://github.com/rcore-os/somehal/pull/39))
- release ([#37](https://github.com/rcore-os/somehal/pull/37))
- 添加对 pie-boot-loader-aarch64 的支持，更新依赖项，新增 Gitee 和 GitHub 的发布获取功能
- Use prebuild loader
- *(somehal)* release v0.3.4 ([#36](https://github.com/rcore-os/somehal/pull/36))
- Loader 改为动态参数 ([#35](https://github.com/rcore-os/somehal/pull/35))
- *(somehal)* release v0.3.3 ([#33](https://github.com/rcore-os/somehal/pull/33))
- 在README中添加测试状态徽章
- *(somehal)* release v0.3.2 ([#32](https://github.com/rcore-os/somehal/pull/32))
- release ([#31](https://github.com/rcore-os/somehal/pull/31))
- 简化trap
- add irq handler
- release ([#30](https://github.com/rcore-os/somehal/pull/30))
- 更新测试配置，移除构建步骤并修正文档中的项目名称
- V03 ([#29](https://github.com/rcore-os/somehal/pull/29))
- Make fdt_ptr() function public ([#28](https://github.com/rcore-os/somehal/pull/28))
- 更新 Rust 分析器配置，启用 "vm" 特性；优化 EL2 切换函数，改用写入方式修改 HCR_EL2；在页表配置中添加共享标志并处理缓存配置。
- log
- update
- update rdrive
- use new rdrive if
- update rdrive
- new rdrive macros
- add rx
- update rdrive
- update
- update
- 优化串口输出
- update
- add el2 clk
- update rdrive
- update rdrive
- update
- 移除percpu依赖 ([#27](https://github.com/rcore-os/somehal/pull/27))
- 优化串口输出
- update
- update
- console out add \r
- adapt percpu feature
- adapt percpu
- adapt percpu
- 25 el2 support ([#26](https://github.com/rcore-os/somehal/pull/26))
- riscv boot
- update
- update
- update
- update
- percpu smp ([#24](https://github.com/rcore-os/somehal/pull/24))
- 2 cpu on  ([#23](https://github.com/rcore-os/somehal/pull/23))
- update
- update
- update ([#22](https://github.com/rcore-os/somehal/pull/22))
- update
- fmt
- update
- update
- update
- update
- update
- update
- update
- 调整 rdrive 链接位置
- update
- update
- update
- update
- update
- update
- update
- update
- power
- update
- update
- add rdrive
- 优化ld
- Merge branch 'main' into 20-引入动态驱动框架实现中断控制器和定时器枚举
- [fix] 树莓派
- update
- fmt
- x86 use any uart
- 18 优化链接脚本便于引入 ([#19](https://github.com/rcore-os/somehal/pull/19))
- 添加x86-64支持 ([#17](https://github.com/rcore-os/somehal/pull/17))
- update
- [fix]add clean bss
- cpu and memory found
- update
- update
- update
- update
- main memory
- rsv
- update
- x86 cpu list
- 11 项目结构优化 ([#12](https://github.com/rcore-os/somehal/pull/12))
- 增加主存保留信息分配器及优化代码 ([#10](https://github.com/rcore-os/somehal/pull/10))
- [fix] starfive2 support ([#9](https://github.com/rcore-os/somehal/pull/9))
- update
- sv39 support
- Move mmu relocate to pie-boot ([#8](https://github.com/rcore-os/somehal/pull/8))
- add dcache flush
- update
- fmt
- update
- fmt
- percpu data ok
- update
- entry
- 增加Riscv支持 ([#3](https://github.com/rcore-os/somehal/pull/3))
- update
- fmt
- fmt
- update
- add riscv
- update
- update
- update
- update
- update
- update
- update
- update
- fmt code
- update
- update
- mmu ok
- init
- update
- fmt
- fmt
- update
- fmt code
- updte
- update
- qemu debug
- update
- print
- update
- pte
- debug
- uboot debug ok
- update
- update
- update
- update
- u
- update
- update
- update
- 内存区域划分
- update
- update
- page table
- update
- update
- update
- update
- link to boot
- update
- update
- update
- debug ok
- debug ok
- update
- update
- update
- init
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).