### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "page-table-generic"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "bitflags 2.9.4",
  "env_logger",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.3.6...pie-boot-loader-aarch64-v0.3.7) - 2026-04-01
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.3.6](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.3.5...pie-boot-loader-aarch64-v0.3.6) - 2026-04-01
 
 ### Fixed

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.3.6"
+version = "0.3.7"
 
 [dependencies]
 aarch64-cpu = "10.0"

--- a/page-table-generic/CHANGELOG.md
+++ b/page-table-generic/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.8](https://github.com/rcore-os/somehal/compare/page-table-generic-v0.6.7...page-table-generic-v0.6.8) - 2026-04-01
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.6.7](https://github.com/rcore-os/somehal/compare/page-table-generic-v0.6.6...page-table-generic-v0.6.7) - 2026-04-01
 
 ### Fixed

--- a/page-table-generic/Cargo.toml
+++ b/page-table-generic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "page-table-generic"
-version = "0.6.7"
+version = "0.6.8"
 authors = ["周睿 <zrufo747@outlook.com>"]
 repository = "https://github.com/rcore-os/somehal/page-table-generic"
 documentation = "https://docs.rs/page-table-generic"

--- a/somehal/CHANGELOG.md
+++ b/somehal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.13](https://github.com/rcore-os/somehal/compare/somehal-v0.4.12...somehal-v0.4.13) - 2026-04-01
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.4.12](https://github.com/rcore-os/somehal/compare/somehal-v0.4.11...somehal-v0.4.12) - 2026-04-01
 
 ### Added

--- a/somehal/Cargo.toml
+++ b/somehal/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.4.12"
+version = "0.4.13"
 
 [features]
 hv = ["kdef-pgtable/space-low"]


### PR DESCRIPTION



## 🤖 New release

* `page-table-generic`: 0.6.7 -> 0.6.8 (✓ API compatible changes)
* `pie-boot-loader-aarch64`: 0.3.6 -> 0.3.7 (✓ API compatible changes)
* `somehal`: 0.4.12 -> 0.4.13 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `page-table-generic`

<blockquote>

## [0.6.8](https://github.com/rcore-os/somehal/compare/page-table-generic-v0.6.7...page-table-generic-v0.6.8) - 2026-04-01

### Other

- update Cargo.toml dependencies
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.3.7](https://github.com/rcore-os/somehal/compare/pie-boot-loader-aarch64-v0.3.6...pie-boot-loader-aarch64-v0.3.7) - 2026-04-01

### Other

- update Cargo.lock dependencies
</blockquote>

## `somehal`

<blockquote>

## [0.4.13](https://github.com/rcore-os/somehal/compare/somehal-v0.4.12...somehal-v0.4.13) - 2026-04-01

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).